### PR TITLE
Move words ignored by codespell from `.codespellignore` to `.codespellrc`

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,1 +1,0 @@
-pullrequest

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = .git
-ignore-words = .codespellignore
+ignore-words-list = pullrequest


### PR DESCRIPTION
Having that `.codespellignore` file there bothered me.